### PR TITLE
Remove src from ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "/.*",
     "examples",
     "package.json",
-    "src",
     "test"
   ],
   "dependencies": {


### PR DESCRIPTION
The src directory is needed so that the js file is available.
